### PR TITLE
Step 10 - Fix bug on category popup

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4277,6 +4277,49 @@
       "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
       "dev": true
     },
+    "mini-css-extract-plugin": {
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/mini-css-extract-plugin/-/mini-css-extract-plugin-1.3.4.tgz",
+      "integrity": "sha512-dNjqyeogUd8ucUgw5sxm1ahvSfSUgef7smbmATRSbDm4EmNx5kQA6VdUEhEeCKSjX6CTYjb5vxgMUvRjqP3uHg==",
+      "dev": true,
+      "requires": {
+        "loader-utils": "^2.0.0",
+        "schema-utils": "^3.0.0",
+        "webpack-sources": "^1.1.0"
+      },
+      "dependencies": {
+        "json5": {
+          "version": "2.1.3",
+          "resolved": "https://registry.npmjs.org/json5/-/json5-2.1.3.tgz",
+          "integrity": "sha512-KXPvOm8K9IJKFM0bmdn8QXh7udDh1g/giieX0NLCaMnb4hEiVFqnop2ImTXCc5e0/oHz3LTqmHGtExn5hfMkOA==",
+          "dev": true,
+          "requires": {
+            "minimist": "^1.2.5"
+          }
+        },
+        "loader-utils": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.0.tgz",
+          "integrity": "sha512-rP4F0h2RaWSvPEkD7BLDFQnvSf+nK+wr3ESUjNTyAGobqrijmW92zc+SO6d4p4B1wh7+B/Jg1mkQe5NYUEHtHQ==",
+          "dev": true,
+          "requires": {
+            "big.js": "^5.2.2",
+            "emojis-list": "^3.0.0",
+            "json5": "^2.1.2"
+          }
+        },
+        "webpack-sources": {
+          "version": "1.4.3",
+          "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-1.4.3.tgz",
+          "integrity": "sha512-lgTS3Xhv1lCOKo7SA5TjKXMjpSM4sBjNV5+q2bqesbSPs5FjGmU6jjtBSkX9b4qW87vDIsCIlUPOEhbZrMdjeQ==",
+          "dev": true,
+          "requires": {
+            "source-list-map": "^2.0.0",
+            "source-map": "~0.6.1"
+          }
+        }
+      }
+    },
     "minimalistic-assert": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "css-loader": "^5.0.1",
     "html-loader": "^1.3.2",
     "html-webpack-plugin": "^4.5.1",
+    "mini-css-extract-plugin": "^1.3.4",
     "sass": "^1.32.5",
     "sass-loader": "^10.1.1",
     "style-loader": "^2.0.0",

--- a/public/js/component/hover_trigger.js
+++ b/public/js/component/hover_trigger.js
@@ -63,9 +63,7 @@ export function initHoverToggle() {
     element.addEventListener('mouseenter', enterHoverToggleTrigger)
 
     // show the first element in each group
-    const toggleTarget = findOne(element.dataset.hoverToggleTarget)
-    const firstElementInGroup = findOne(`[data-hover-toggle-group="${toggleTarget.dataset.hoverToggleGroup}"]`)
-    firstElementInGroup.classList.add('show')
+    enterHoverToggleTrigger({ target: element })
   })
 }
 

--- a/public/js/component/multinav.js
+++ b/public/js/component/multinav.js
@@ -7,11 +7,11 @@ function getNavListItemHtmlString({ title, href }, hoverToggleTarget) {
   return `
     <li
       role="button"
-      class="nav-item hover-bg-white"
+      class="hover-bg-white"
       ${hoverToggleTarget ? `data-hover-toggle-target="#${hoverToggleTarget}"` : ''}
     >
     ${href ? `<a href="${href}">` : ``}
-      ${title}
+      <p class="px-3 py-2 m-0">${title}</p>
     ${href ? `</a>` : ``}
     </li>`
 }

--- a/public/js/component/multinav.js
+++ b/public/js/component/multinav.js
@@ -16,7 +16,7 @@ function getNavListItemHtmlString({ title, href }, hoverToggleTarget) {
     </li>`
 }
 
-function getMultiNavHtmlString(id, dataList, depth, isMainNav = false) {
+function getMultiNavHtmlString({ group, id, dataList, depth, isMainNav = false }) {
   /*
 
   dataList: array of {
@@ -37,7 +37,7 @@ function getMultiNavHtmlString(id, dataList, depth, isMainNav = false) {
     <div
       id="${id}"
       class="d-flex flex-${depth} ${isMainNav ? `bg-light` : `bg-white text-small`}"
-      ${isMainNav ? `` : `data-hover-toggle-group="multinav-depth-${depth}"`}
+      ${isMainNav ? `` : `data-hover-toggle-group="${group}"`}
       data-hover-hide-delay="${HOVER_HIDE_DELAY}"
     >`
 
@@ -58,8 +58,10 @@ function getMultiNavHtmlString(id, dataList, depth, isMainNav = false) {
 
       // push sub-nav data to {subNavDataList}
       subNavDataList.push({
+        group: id,
         id: subNavID,
-        dataList: data.data
+        dataList: data.data,
+        depth: depth - 1,
       })
     }
 
@@ -75,7 +77,7 @@ function getMultiNavHtmlString(id, dataList, depth, isMainNav = false) {
 
   // append sub-nav (if exist)
   htmlString += subNavDataList.reduce((htmlString, subNavData) =>
-    htmlString + getMultiNavHtmlString(subNavData.id, subNavData.dataList, depth - 1), '')
+    htmlString + getMultiNavHtmlString(subNavData), '')
 
   // close wrapper
   htmlString += `</div>`
@@ -86,10 +88,12 @@ function getMultiNavHtmlString(id, dataList, depth, isMainNav = false) {
 
 // append multinav to the wrapper
 export function appendMultiNav(wrapper) {
-  wrapper.innerHTML += getMultiNavHtmlString(
-    'multinav',     // id
-    MULTINAV_DATA,  // dataList
-    MULTINAV_DEPTH, // depth
-    true            // isMainNav
-  )
+  const navData = {
+    id:        'multinav',
+    dataList:  MULTINAV_DATA,
+    depth:     MULTINAV_DEPTH,
+    isMainNav: true,
+  }
+
+  wrapper.innerHTML += getMultiNavHtmlString(navData)
 }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,5 +1,6 @@
 const path = require('path');
 const HtmlWebpackPlugin = require('html-webpack-plugin')
+const MiniCssExtractPlugin = require('mini-css-extract-plugin')
 
 module.exports = {
   entry: './webpack-entry.js',
@@ -43,8 +44,10 @@ module.exports = {
       {
         test: /\.s[ac]ss$/i,
         use: [
+          // extracts CSS into separate files
+          MiniCssExtractPlugin.loader,
           // inject CSS into the DOM
-          { loader: 'style-loader' },
+          // { loader: 'style-loader' },
           // interprets @import and url() like import/require() and will resolve them
           {
             loader: 'css-loader',
@@ -63,7 +66,8 @@ module.exports = {
   plugins: [
     new HtmlWebpackPlugin({
       template: './views/index.html'
-    })
+    }),
+    new MiniCssExtractPlugin()
   ],
   mode: 'development'
 };


### PR DESCRIPTION
- multinav 개선
  - toggle group 버그 수정
  - 각 항목의 padding 수정하여 <a> 태그 영역을 최대로 넓힘
- 중복된 코드 제거
- webpack에 __MiniCssExtractPlugin__ 플러그인 적용
  - CSS를 script.bundle.js에서 분리하고 <head> 태그 내에 <link>로 삽입
    - 페이지 로드 시 CSS 적용 지연으로 인한 화면 깜빡임 문제를 해결

(새 브랜치를 생성을 까먹어서 step-9 브랜치가 되었습니다.)